### PR TITLE
Current path returns "Select Folder" instead of an empty string

### DIFF
--- a/lib/src/ui/page/photo_main_page.dart
+++ b/lib/src/ui/page/photo_main_page.dart
@@ -66,7 +66,7 @@ class _PhotoMainPageState extends State<PhotoMainPage>
     if (currentPath?.isAll == true) {
       return i18nProvider.getAllGalleryText(options);
     }
-    return currentPath?.name ?? "";
+    return currentPath?.name ?? "Select Folder";
   }
 
   GlobalKey scaffoldKey;


### PR DESCRIPTION
With an empty string the button is hard to see and tap.

Anyway in the old version I got the name of all the folders while now with this version I get always no name.