### PR TITLE
Fix picking unlimited amount of media items

### DIFF
--- a/lib/src/provider/config_provider.dart
+++ b/lib/src/provider/config_provider.dart
@@ -28,4 +28,8 @@ class PhotoPickerProvider extends InheritedWidget {
 
   static AssetProvider assetProviderOf(BuildContext context) =>
       of(context).assetProvider;
+
+  String getSureText(selectedCount) => options.maxSelected == null
+      ? provider.getSureText(options, selectedCount)
+      : provider.getSureTextWithMax(options, selectedCount);
 }

--- a/lib/src/provider/i18n_provider.dart
+++ b/lib/src/provider/i18n_provider.dart
@@ -8,6 +8,8 @@ abstract class I18nProvider {
 
   String getSureText(Options options, int currentCount);
 
+  String getSureTextWithMax(Options options, int currentCount);
+
   String getPreviewText(Options options, SelectedProvider selectedProvider);
 
   String getSelectedOptionsText(Options options);
@@ -48,6 +50,11 @@ class CNProvider extends I18nProvider {
 
   @override
   String getSureText(Options options, int currentCount) {
+    return "确定($currentCount)";
+  }
+
+  @override
+  String getSureTextWithMax(Options options, int currentCount) {
     return "确定($currentCount/${options.maxSelected})";
   }
 
@@ -98,6 +105,11 @@ class ENProvider extends I18nProvider {
 
   @override
   String getSureText(Options options, int currentCount) {
+    return "Save ($currentCount)";
+  }
+
+  @override
+  String getSureTextWithMax(Options options, int currentCount) {
     return "Save ($currentCount/${options.maxSelected})";
   }
 
@@ -140,6 +152,11 @@ class DEProvider extends I18nProvider {
 
   @override
   String getSureText(Options options, int currentCount) {
+    return "Speichern ($currentCount)";
+  }
+
+  @override
+  String getSureTextWithMax(Options options, int currentCount) {
     return "Speichern ($currentCount/${options.maxSelected})";
   }
 

--- a/lib/src/ui/page/photo_main_page.dart
+++ b/lib/src/ui/page/photo_main_page.dart
@@ -138,7 +138,7 @@ class _PhotoMainPageState extends State<PhotoMainPage>
               FlatButton(
                 splashColor: Colors.transparent,
                 child: Text(
-                  i18nProvider.getSureText(options, selectedCount),
+                  PhotoPickerProvider.of(context).getSureText(selectedCount),
                   style: selectedCount == 0
                       ? textStyle.copyWith(color: options.disableColor)
                       : textStyle,

--- a/lib/src/ui/page/photo_preview_page.dart
+++ b/lib/src/ui/page/photo_preview_page.dart
@@ -151,7 +151,7 @@ class _PhotoPreviewPageState extends State<PhotoPreviewPage> {
                 splashColor: Colors.transparent,
                 onPressed: selectedList.length == 0 ? null : sure,
                 child: Text(
-                  config.provider.getSureText(options, selectedList.length),
+                  config.getSureText(selectedList.length),
                   style: selectedList.length == 0
                       ? textStyle.copyWith(color: options.disableColor)
                       : textStyle,


### PR DESCRIPTION
I noticed that passing "null" as value for "maxSelected" option causes the picker to show incorrect text within "Save" button in the action bar. It will display (4/null) for example.

This commit tries to fix this behaviour, by providing separate i18n key, if "maxSelected" is null and therefore unlimited amount of media items can be chosen.

I hope the chinese translation can still be applied in this case, please check this.