### PR TITLE
PR: 扩展能加入自定义前置元素，比如拍照按钮

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ void pickAsset() async {
       pickType: type, // all/image/video
 
       List<AssetPathEntity> photoPathList, /// when [photoPathList] is not null , [pickType] invalid .
+
+      PhotoPreviousBuilder previousBuilder,
+      // custom widget before items, and size should be 64.0 . eg: “camera” button at first.
     );
 ```
 

--- a/lib/photo.dart
+++ b/lib/photo.dart
@@ -94,6 +94,7 @@ class PhotoPicker {
     BadgeDelegate badgeDelegate = const DefaultBadgeDelegate(),
     List<AssetPathEntity> photoPathList,
     List<AssetEntity> pickedAssetList,
+    PhotoPreviousBuilder previousBuilder,
   }) {
     assert(provider != null, "provider must be not null");
     assert(context != null, "context must be not null");
@@ -124,6 +125,7 @@ class PhotoPicker {
       loadingDelegate: loadingDelegate,
       badgeDelegate: badgeDelegate,
       pickType: pickType,
+      previousBuilder: previousBuilder,
     );
 
     return PhotoPicker()._pickAsset(

--- a/lib/src/entity/options.dart
+++ b/lib/src/entity/options.dart
@@ -4,6 +4,7 @@ import 'package:photo/src/delegate/checkbox_builder_delegate.dart';
 import 'package:photo/src/delegate/loading_delegate.dart';
 import 'package:photo/src/delegate/sort_delegate.dart';
 
+typedef PhotoPreviousBuilder = Widget Function(BuildContext context);
 class Options {
   final int rowCount;
 
@@ -33,6 +34,8 @@ class Options {
 
   final PickType pickType;
 
+  final PhotoPreviousBuilder previousBuilder;
+
   const Options({
     this.rowCount,
     this.maxSelected,
@@ -48,6 +51,7 @@ class Options {
     this.loadingDelegate,
     this.badgeDelegate,
     this.pickType,
+    this.previousBuilder
   });
 }
 

--- a/lib/src/ui/page/photo_main_page.dart
+++ b/lib/src/ui/page/photo_main_page.dart
@@ -80,6 +80,12 @@ class _PhotoMainPageState extends State<PhotoMainPage>
 
   Throttle _changeThrottle;
 
+  int get previousWidgetsCount {
+    if (options.previousBuilder != null) {
+      return 1;
+    } else return 0;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -275,16 +281,28 @@ class _PhotoMainPageState extends State<PhotoMainPage>
           mainAxisSpacing: options.padding,
         ),
         itemBuilder: _buildItem,
-        itemCount: count,
+        itemCount: count + previousWidgetsCount,
       ),
     );
   }
 
   Widget _buildItem(BuildContext context, int index) {
+    if (options.previousBuilder != null) {
+      if (index == 0) {
+        return options.previousBuilder(context);
+      } else {
+        index--;
+      }
+    }
+
     final noMore = assetProvider.noMore;
     if (!noMore && index == assetProvider.count) {
       _loadMore();
       return _buildLoading();
+    }
+
+    if (list.length < 1) {
+      return new Container();
     }
 
     var data = list[index];


### PR DESCRIPTION
项目中有个需求，能像微信选图片一样，此界面也要有拍照按钮。

因此拓展 previousBuilder 属性来让开发者自定义列表之前的元素，
没想太多其他情况，比如该元素尺寸或多个元素等问题，仅算是个思路吧。

举个例子，利用该属性新加个元素，然后用 `image_picker` 实现拍照效果。

```dart
previousBuilder: (BuildContext context) {
  return new GestureDetector(
    onTap: () async {
      Navigator.of(context).pop();
      PickedFile image = await ImagePicker().getImage(source: ImageSource.camera, imageQuality: 30);
      if (image == null) return;
      print('${image.path}');
    },
    child: new Container(
      width: 64,
      height: 64,
      color: Colors.white,
      child: new Center(child: new Text('拍照')),
    ),
  );
}
```

<img src="https://user-images.githubusercontent.com/22021589/85262393-4a261c00-b4a0-11ea-9adc-2cb7d144884b.jpg" width="300"/>