### PR TITLE
Fix: flutter 2 makes BuildContext generic method breaking change

### DIFF
--- a/lib/src/provider/config_provider.dart
+++ b/lib/src/provider/config_provider.dart
@@ -24,7 +24,7 @@ class PhotoPickerProvider extends InheritedWidget {
   }
 
   static PhotoPickerProvider of(BuildContext context) =>
-      context.inheritFromWidgetOfExactType(PhotoPickerProvider);
+      context.dependOnInheritedWidgetOfExactType<PhotoPickerProvider>();
 
   static AssetProvider assetProviderOf(BuildContext context) =>
       of(context).assetProvider;


### PR DESCRIPTION
Flutter had made the BuildContext method `inheritFromWidgetOfExactType` generic. Instead `dependOnInheritedWidgetOfExactType` method should be used.

It's a breaking change in flutter 2.

Fix: #147

Reference: https://github.com/flutter/flutter/pull/44189